### PR TITLE
SIGUSR1 support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1680,6 +1680,7 @@ dependencies = [
  "iced 0.14.0-dev",
  "iced_layershell",
  "image",
+ "signal-hook",
  "sipper",
  "tokio",
  "tokio-util",

--- a/Readme.md
+++ b/Readme.md
@@ -22,7 +22,7 @@ as I've stolen all the ANSI and text grid functionality from them.
 This is still really basic. If you have requests for the widget or application, feel free to open an issue.
 
 - Builtin nerd font, no more installing additinoal fonts for oh-my-posh or oh-my-zsh
-- Dropdown Terminal via Hotkey (F12 on Linux, Alt + F12 on Windows)
+- Dropdown Terminal via Hotkey (F12 on Linux, Alt + F12 on Windows) or via SIGUSR1
 - Wayland support through iced_layershell (still a bit unstable)
 - Multiple Tabs
 - Copy and paste via context menu or (Ctrl + Shift + C/V)

--- a/frostbyte_term/Cargo.toml
+++ b/frostbyte_term/Cargo.toml
@@ -15,6 +15,7 @@ global-hotkey = "0.7.0"
 tray-icon = "0.20.1"
 tokio = "1.45.0"
 image = { version = "0.25.6", default-features = false, features = ["png"] }
+signal-hook = "0.3.18"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 iced_layershell = { git = "https://github.com/waycrate/exwlshelleventloop.git", branch = "iced14" }

--- a/frostbyte_term/src/ui.rs
+++ b/frostbyte_term/src/ui.rs
@@ -1,4 +1,7 @@
-use std::{collections::BTreeMap, fmt::Debug, time::Duration};
+use std::{collections::BTreeMap, fmt::Debug, sync::{atomic::{AtomicUsize, Ordering}, Arc}, time::Duration};
+
+use signal_hook::consts::signal::SIGUSR1;
+use signal_hook::flag as signal_flag;
 
 use global_hotkey::{GlobalHotKeyEvent, GlobalHotKeyManager, HotKeyState, hotkey};
 use iced::{
@@ -420,8 +423,22 @@ fn poll_events_sub() -> impl Stream<Item = Message> {
 
         let tray_menu_receiver = tray_icon::menu::MenuEvent::receiver();
         let tray_icon_receiver = tray_icon::TrayIconEvent::receiver();
+
+        let mut term = Arc::new(AtomicUsize::new(0));
+        const SIGUSR1_U: usize = SIGUSR1 as usize;
+        signal_flag::register_usize(SIGUSR1, Arc::clone(&term), SIGUSR1_U).unwrap();
+
         // poll for global hotkey events every 50ms
         loop {
+            //remeber to zero out term and reset the listener
+            if term.load(Ordering::Relaxed) == SIGUSR1_U {
+                if let Err(err) = sender.send(Message::Hotkey).await {
+                        eprintln!("Error sending hotkey message: {}", err);
+                    }
+                term = Arc::new(AtomicUsize::new(0));
+                signal_flag::register_usize(SIGUSR1, Arc::clone(&term), SIGUSR1_U).unwrap();
+            }
+
             if let Ok(event) = hotkey_receiver.try_recv() {
                 if event.state() == HotKeyState::Pressed {
                     if let Err(err) = sender.send(Message::Hotkey).await {

--- a/frostbyte_term/src/ui.rs
+++ b/frostbyte_term/src/ui.rs
@@ -1,4 +1,12 @@
-use std::{collections::BTreeMap, fmt::Debug, sync::{atomic::{AtomicUsize, Ordering}, Arc}, time::Duration};
+use std::{
+    collections::BTreeMap,
+    fmt::Debug,
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::Duration,
+};
 
 use signal_hook::consts::signal::SIGUSR1;
 use signal_hook::flag as signal_flag;
@@ -430,11 +438,11 @@ fn poll_events_sub() -> impl Stream<Item = Message> {
 
         // poll for global hotkey events every 50ms
         loop {
-            //remeber to zero out term and reset the listener
+            // You need to zero out and reset listener in loop
             if term.load(Ordering::Relaxed) == SIGUSR1_U {
                 if let Err(err) = sender.send(Message::Hotkey).await {
-                        eprintln!("Error sending hotkey message: {}", err);
-                    }
+                    eprintln!("Error sending hotkey message: {}", err);
+                }
                 term = Arc::new(AtomicUsize::new(0));
                 signal_flag::register_usize(SIGUSR1, Arc::clone(&term), SIGUSR1_U).unwrap();
             }

--- a/frostbyte_term/src/ui.rs
+++ b/frostbyte_term/src/ui.rs
@@ -432,19 +432,19 @@ fn poll_events_sub() -> impl Stream<Item = Message> {
         let tray_menu_receiver = tray_icon::menu::MenuEvent::receiver();
         let tray_icon_receiver = tray_icon::TrayIconEvent::receiver();
 
-        let mut term = Arc::new(AtomicUsize::new(0));
+        let mut flag_counter = Arc::new(AtomicUsize::new(0));
         const SIGUSR1_U: usize = SIGUSR1 as usize;
-        signal_flag::register_usize(SIGUSR1, Arc::clone(&term), SIGUSR1_U).unwrap();
+        signal_flag::register_usize(SIGUSR1, Arc::clone(&flag_counter), SIGUSR1_U).unwrap();
 
         // poll for global hotkey events every 50ms
         loop {
             // You need to zero out and reset listener in loop
-            if term.load(Ordering::Relaxed) == SIGUSR1_U {
+            if flag_counter.load(Ordering::Relaxed) == SIGUSR1_U {
                 if let Err(err) = sender.send(Message::Hotkey).await {
                     eprintln!("Error sending hotkey message: {}", err);
                 }
-                term = Arc::new(AtomicUsize::new(0));
-                signal_flag::register_usize(SIGUSR1, Arc::clone(&term), SIGUSR1_U).unwrap();
+                flag_counter = Arc::new(AtomicUsize::new(0));
+                signal_flag::register_usize(SIGUSR1, Arc::clone(&flag_counter), SIGUSR1_U).unwrap();
             }
 
             if let Ok(event) = hotkey_receiver.try_recv() {


### PR DESCRIPTION
This allows toggling the terminal using sig usr1. This is useful since not all compositors/DEs support global hotkeys. Currently testing this on cosmic-comp and it is working fine for me :D Tested with `pkill -USR1 frostbyte_term` sorry for all the commits, just fluff and didn't have time to squash